### PR TITLE
Add support for CSS variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,70 @@ If you are using [Expo](https://expo.io/), instead of adding the `rn-cli.config.
 }
 ```
 
+## CSS Custom Properties (CSS variables)
+
+CSS variables are not supported by default, but you can add support for them by using [PostCSS](https://postcss.org/) and [postcss-css-variables](https://github.com/MadLittleMods/postcss-css-variables#readme) plugin.
+
+Start by installing dependencies:
+
+```sh
+yarn add postcss postcss-css-variables react-native-postcss-transformer --dev
+```
+
+After that create a `transformer.js` file and do the following:
+
+```js
+// For React Native version 0.59 or later
+var upstreamTransformer = require("metro-react-native-babel-transformer");
+
+// For React Native version 0.56-0.58
+// var upstreamTransformer = require("metro/src/reactNativeTransformer");
+
+// For React Native version 0.52-0.55
+// var upstreamTransformer = require("metro/src/transformer");
+
+// For React Native version 0.47-0.51
+// var upstreamTransformer = require("metro-bundler/src/transformer");
+
+// For React Native version 0.46
+// var upstreamTransformer = require("metro-bundler/build/transformer");
+
+var stylusTransformer = require("react-native-stylus-transformer");
+var postCSSTransformer = require("react-native-postcss-transformer");
+
+module.exports.transform = function({ src, filename, options }) {
+  if (filename.endsWith(".styl")) {
+    return stylusTransformer
+      .renderToCSS({ src, filename, options })
+      .then(css =>
+        postCSSTransformer.transform({ src: css, filename, options })
+      );
+  } else {
+    return upstreamTransformer.transform({ src, filename, options });
+  }
+};
+```
+
+After that in `metro.config.js` point the `babelTransformerPath` to that file:
+
+```js
+const { getDefaultConfig } = require("metro-config");
+
+module.exports = (async () => {
+  const {
+    resolver: { sourceExts }
+  } = await getDefaultConfig();
+  return {
+    transformer: {
+      babelTransformerPath: require.resolve("./transformer.js")
+    },
+    resolver: {
+      sourceExts: [...sourceExts, "styl"]
+    }
+  };
+})();
+```
+
 ## Dependencies
 
 This library has the following Node.js modules as dependencies:

--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ Start by installing dependencies:
 yarn add postcss postcss-css-variables react-native-postcss-transformer --dev
 ```
 
+Add `postcss-css-variables` to your PostCSS configuration with [one of the supported config formats](https://github.com/michael-ciniawsky/postcss-load-config), e.g. `package.json`, `.postcssrc`, `postcss.config.js`, etc.
+
 After that create a `transformer.js` file and do the following:
 
 ```js

--- a/index.js
+++ b/index.js
@@ -27,6 +27,18 @@ if (reactNativeMinorVersion >= 59) {
   };
 }
 
+function renderToCSS({ src, filename, options }) {
+  return stylus.render(src, { filename });
+}
+
+function renderToCSSPromise(css) {
+  return Promise.resolve(renderToCSS(css));
+}
+
+function renderCSSToReactNative(css) {
+  return css2rn(css, { parseMediaQueries: true });
+}
+
 module.exports.transform = function(src, filename, options) {
   if (typeof src === "object") {
     // handle RN >= 0.46
@@ -34,10 +46,8 @@ module.exports.transform = function(src, filename, options) {
   }
 
   if (filename.endsWith(".styl")) {
-    var cssObject = css2rn(stylus.render(src, { filename }), {
-      parseMediaQueries: true
-    });
-
+    var css = renderToCSS({ src, filename, options });
+    var cssObject = renderCSSToReactNative(css);
     return upstreamTransformer.transform({
       src: "module.exports = " + JSON.stringify(cssObject),
       filename,
@@ -46,3 +56,5 @@ module.exports.transform = function(src, filename, options) {
   }
   return upstreamTransformer.transform({ src, filename, options });
 };
+
+module.exports.renderToCSS = renderToCSSPromise;


### PR DESCRIPTION
Add `renderToCSS` function that can be used to first render Stylus to CSS, and then to pass the result to PostCSS.

fixes #6